### PR TITLE
Mm integration

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -53,6 +53,10 @@ jobs:
         run: |
           # Fix for git not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
+      - name: Install requirements
+        run: |
+          pip install -r requirements.txt
+        shell: bash
       - name: Build and Test
         env:
           CMAIZE_GITHUB_TOKEN: ${{secrets.CMAIZE_GITHUB_TOKEN}}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -29,3 +29,43 @@ jobs:
       compilers: ''
       doc_target: 'sphinx'
     secrets: inherit
+
+  # PluginPlayer needs pluginplay_examples, which means PluginPlays test have to
+  # be built. This means that CTest will run both PluginPlayer's and 
+  # PluginPlay's tests, which is not desired. For now, I'm running this job to 
+  # test PluginPlayer using ctest -R to limit the tests.
+  # TODO: Either refactor the test to not need pluginplay_examples, refactor
+  # PluginPlay so that pluginplay_examples can be build without the tests,
+  # or refactor the common workflow to allow for regex specification.
+  test_library:
+    needs: Common-Pull-Request
+    runs-on: ubuntu-latest
+    container: 
+      image: ghcr.io/nwchemex/nwx_buildenv:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.CONTAINER_REPO_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set ownership
+        run: |
+          # Fix for git not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
+      - name: Build and Test
+        env:
+          CMAIZE_GITHUB_TOKEN: ${{secrets.CMAIZE_GITHUB_TOKEN}}
+        run:  |
+          toolchain=/toolchains/nwx_gcc-11.cmake
+          echo 'set(CMAIZE_GITHUB_TOKEN '${CMAIZE_GITHUB_TOKEN}')' >> $toolchain
+
+          cmake -Bbuild -H. -GNinja \
+          -DCMAKE_INSTALL_PREFIX=./install \
+          -DCMAKE_TOOLCHAIN_FILE="${toolchain}"
+       
+          cmake --build build --parallel
+        
+          cd build
+          OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 ctest -VV -R pluginplayer
+        shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright 2022 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.14)
+
+#Downloads common CMake modules used throughout NWChemEx
+include(cmake/get_nwx_cmake.cmake)
+
+#Sets the version to whatever git thinks it is
+include(get_version_from_git)
+get_version_from_git(pluginplayer_version "${CMAKE_CURRENT_LIST_DIR}")
+project(pluginplayer VERSION "${pluginplayer_version}" LANGUAGES CXX)
+
+include(nwx_versions)
+include(get_cmaize)
+include(nwx_cxx_api_docs)
+
+### Files and Paths ###
+set(python_src_directory "${CMAKE_CURRENT_LIST_DIR}/src/")
+
+# # Doxygen docs
+nwx_cxx_api_docs("${CMAKE_CURRENT_SOURCE_DIR}/src" "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+### Options ###
+cmaize_option_list(
+    BUILD_TESTING OFF "Should we build the tests?"
+)
+
+### Tests need PluginPlay examples ##
+if("${BUILD_TESTING}")
+    set(PP_BUILD_TARGETS pluginplay pluginplay_examples)
+    set(PP_FIND_TARGETS nwx::pluginplay nwx::pluginplay_depends)
+    set(PP_BUILD_TESTS ON)
+else()
+    set(PP_BUILD_TARGETS pluginplay)
+    set(PP_FIND_TARGETS nwx::pluginplay)
+    set(PP_BUILD_TESTS OFF)
+endif()
+
+## Build FriendZone's dependencies ##
+cmaize_find_or_build_dependency(
+    pluginplay
+    URL github.com/NWChemEx/PluginPlay
+    VERSION ${NWX_PLUGINPLAY_VERSION}
+    BUILD_TARGET ${PP_BUILD_TARGETS}
+    FIND_TARGET ${PP_FIND_TARGETS}
+    CMAKE_ARGS BUILD_TESTING=${PP_BUILD_TESTS}
+               BUILD_PYBIND11_PYBINDINGS=ON
+)
+
+#TOOD: Replace cmaize_add_library when it supports Python
+add_library(${PROJECT_NAME} INTERFACE)
+target_link_libraries(${PROJECT_NAME} INTERFACE pluginplay)
+
+if("${BUILD_TESTING}")
+    include(CTest)
+    include(nwx_pybind11)
+    set(PYTHON_TEST_DIR "${CMAKE_CURRENT_LIST_DIR}/tests")
+
+    nwx_pybind11_tests(
+        py_${PROJECT_NAME}
+        "${PYTHON_TEST_DIR}/test_pluginplayer.py"
+        SUBMODULES pluginplay_examples pluginplay parallelzone
+    )
+endif()
+
+install(
+    DIRECTORY "${python_src_directory}/pluginplayer"
+    DESTINATION "${NWX_MODULE_DIRECTORY}"
+)

--- a/cmake/get_nwx_cmake.cmake
+++ b/cmake/get_nwx_cmake.cmake
@@ -1,0 +1,31 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+
+macro(get_nwx_cmake)
+    include(FetchContent)
+    FetchContent_Declare(
+        nwx_cmake
+        GIT_REPOSITORY https://github.com/NWChemEx/NWXCMake
+    )
+    FetchContent_MakeAvailable(nwx_cmake)
+    set(
+        CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${nwx_cmake_SOURCE_DIR}/cmake"
+        CACHE STRING ""
+        FORCE
+    )
+endmacro()
+
+get_nwx_cmake()

--- a/src/pluginplayer/node_manager.py
+++ b/src/pluginplayer/node_manager.py
@@ -192,7 +192,7 @@ class NodeManager():
         key_name = list(node.submod_dict.keys())[key_number]
         plugin_number = int(instance.id.split()[2])
         submodule_number = int(instance.id.split()[3])
-        submodule_name = self.saved_plugins[plugin_number].modules[
+        submodule_name = self.plugin_player.plugin_manager.saved_plugins[plugin_number].modules[
             submodule_number]
 
         try:

--- a/src/pluginplayer/node_manager.py
+++ b/src/pluginplayer/node_manager.py
@@ -192,8 +192,8 @@ class NodeManager():
         key_name = list(node.submod_dict.keys())[key_number]
         plugin_number = int(instance.id.split()[2])
         submodule_number = int(instance.id.split()[3])
-        submodule_name = self.plugin_player.plugin_manager.saved_plugins[plugin_number].modules[
-            submodule_number]
+        submodule_name = self.plugin_player.plugin_manager.saved_plugins[
+            plugin_number].modules[submodule_number]
 
         try:
             self.plugin_player.mm.change_submod(module_name, key_name,

--- a/src/pluginplayer/node_widget.py
+++ b/src/pluginplayer/node_widget.py
@@ -15,6 +15,7 @@
 from kivy.uix.image import Image
 from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.textinput import TextInput
 
 
 class DraggableImageButton(ButtonBehavior, BoxLayout):
@@ -199,7 +200,9 @@ class ModuleNode:
         self.module_widget = None
 
         #holds the widget of the custom declaration of the currently selected input
-        self.custom_declaration_widget = None
+        self.custom_declaration_widget = TextInput(hint_text="ex: Force()",
+                               size_hint_x=3 / 5,
+                               multiline=False)
 
         #show the mapping of inputs, outputs and submodules used for running the tree
         self.input_map = []

--- a/src/pluginplayer/node_widget.py
+++ b/src/pluginplayer/node_widget.py
@@ -201,8 +201,8 @@ class ModuleNode:
 
         #holds the widget of the custom declaration of the currently selected input
         self.custom_declaration_widget = TextInput(hint_text="ex: Force()",
-                               size_hint_x=3 / 5,
-                               multiline=False)
+                                                   size_hint_x=3 / 5,
+                                                   multiline=False)
 
         #show the mapping of inputs, outputs and submodules used for running the tree
         self.input_map = []

--- a/src/pluginplayer/node_widget_manager.py
+++ b/src/pluginplayer/node_widget_manager.py
@@ -221,7 +221,8 @@ class NodeWidgetManager():
         custom_ptype = BoxLayout(orientation='horizontal', spacing=0)
 
         if node.custom_declaration_widget.parent:
-            node.custom_declaration_widget.parent.remove_widget(node.custom_declaration_widget)
+            node.custom_declaration_widget.parent.remove_widget(
+                node.custom_declaration_widget)
         #add text entry to the node's properties
         custom_ptype.add_widget(node.custom_declaration_widget)
 

--- a/src/pluginplayer/node_widget_manager.py
+++ b/src/pluginplayer/node_widget_manager.py
@@ -219,13 +219,11 @@ class NodeWidgetManager():
 
         #create an entry to declare a property type
         custom_ptype = BoxLayout(orientation='horizontal', spacing=0)
-        text_entry = TextInput(hint_text="ex: Force()",
-                               size_hint_x=3 / 5,
-                               multiline=False)
 
+        if node.custom_declaration_widget.parent:
+            node.custom_declaration_widget.parent.remove_widget(node.custom_declaration_widget)
         #add text entry to the node's properties
-        node.custom_declaration_widget = text_entry
-        custom_ptype.add_widget(text_entry)
+        custom_ptype.add_widget(node.custom_declaration_widget)
 
         #add button to set the property type
         custom_entry_button = Button(

--- a/src/pluginplayer/plugin_player.py
+++ b/src/pluginplayer/plugin_player.py
@@ -19,11 +19,11 @@ import sys
 
 #helper classes for a PluginPlayer interface
 import pluginplay as pp
-from plugin_manager import PluginManager
-from tree_manager import TreeManager
-from node_widget_manager import NodeWidgetManager
-from node_manager import NodeManager
-from utility_manager import UtilityManager
+from pluginplayer.plugin_manager import PluginManager
+from pluginplayer.tree_manager import TreeManager
+from pluginplayer.node_widget_manager import NodeWidgetManager
+from pluginplayer.node_manager import NodeManager
+from pluginplayer.utility_manager import UtilityManager
 
 #kivy helpers
 from kivy.app import App

--- a/src/pluginplayer/plugin_player.py
+++ b/src/pluginplayer/plugin_player.py
@@ -48,12 +48,8 @@ class PluginPlayer(App):
     :rtype: kivy.app.App
     """
 
-    #build the main window from the kv file
-    def build(self):
-        """Builds the main window from the plugin_player_setup.kv file, and creates instances of helper classes to alter the imported plugins and tree structure.
-
-        :return: The built Kivy application
-        :rtype: kivy.app.App
+    def test_setup(self):
+        """Initializes the helpers and instance variables for the PluginPlayer class for testing
         """
         self.popup = Popup()
 
@@ -77,6 +73,42 @@ class PluginPlayer(App):
 
         #helper class handling browsing, imported class types, and importing new classes
         self.utility_manager = UtilityManager()
+
+    
+
+    #build the main window from the kv file
+    def build(self):
+        """Builds the main window from the plugin_player_setup.kv file, and creates instances of helper classes to alter the imported plugins and tree structure.
+
+        :return: The built Kivy application
+        :rtype: kivy.app.App
+        """
+        
+        self.popup = Popup()
+
+        #The app's module manager
+        self.mm = pp.ModuleManager()
+
+        #saved tree containing the nodes and modules to be ran
+        self.nodes = []
+
+        #helper class handling addition/removal of nodes, deleting/running the tree
+        self.tree_manager = TreeManager(self)
+
+        #helper class handling the widget building for the node configuration
+        self.node_widget_manager = NodeWidgetManager(self)
+
+        #helper class handling the linking of inputs, submods, property types between modules
+        self.node_manager = NodeManager(self)
+
+        #helper class handling the loading, deleting, and viewing of plugins and their modules
+        self.plugin_manager = PluginManager(self)
+
+        #helper class handling browsing, imported class types, and importing new classes
+        self.utility_manager = UtilityManager()
+
+        #string array holding the filepaths of resized images
+        self.resized_images = []
 
         #build the main application from the kivy script file
         build = Builder.load_file('plugin_player_setup.kv')
@@ -146,6 +178,12 @@ class PluginPlayer(App):
         image = PILImage.open(filepath)
         resized_image = image.resize(size)
         resized_image.save(new_filepath)
+        self.resized_images.append(new_filepath)
+
+    def on_stop(self):
+        for filepath in self.resized_images:
+            if os.path.exists(filepath):
+                os.remove(filepath)
 
 
 if __name__ == "__main__":

--- a/src/pluginplayer/plugin_player.py
+++ b/src/pluginplayer/plugin_player.py
@@ -48,32 +48,6 @@ class PluginPlayer(App):
     :rtype: kivy.app.App
     """
 
-    def test_setup(self):
-        """Initializes the helpers and instance variables for the PluginPlayer class for testing
-        """
-        self.popup = Popup()
-
-        #The app's module manager
-        self.mm = pp.ModuleManager()
-
-        #saved tree containing the nodes and modules to be ran
-        self.nodes = []
-
-        #helper class handling addition/removal of nodes, deleting/running the tree
-        self.tree_manager = TreeManager(self)
-
-        #helper class handling the widget building for the node configuration
-        self.node_widget_manager = NodeWidgetManager(self)
-
-        #helper class handling the linking of inputs, submods, property types between modules
-        self.node_manager = NodeManager(self)
-
-        #helper class handling the loading, deleting, and viewing of plugins and their modules
-        self.plugin_manager = PluginManager(self)
-
-        #helper class handling browsing, imported class types, and importing new classes
-        self.utility_manager = UtilityManager()
-
     #build the main window from the kv file
     def build(self):
         """Builds the main window from the plugin_player_setup.kv file, and creates instances of helper classes to alter the imported plugins and tree structure.
@@ -179,6 +153,8 @@ class PluginPlayer(App):
         self.resized_images.append(new_filepath)
 
     def on_stop(self):
+        """On the closing of the application, the saved resized images used in the application are located and deleted.
+        """
         for filepath in self.resized_images:
             if os.path.exists(filepath):
                 os.remove(filepath)

--- a/src/pluginplayer/plugin_player.py
+++ b/src/pluginplayer/plugin_player.py
@@ -74,8 +74,6 @@ class PluginPlayer(App):
         #helper class handling browsing, imported class types, and importing new classes
         self.utility_manager = UtilityManager()
 
-    
-
     #build the main window from the kv file
     def build(self):
         """Builds the main window from the plugin_player_setup.kv file, and creates instances of helper classes to alter the imported plugins and tree structure.
@@ -83,7 +81,7 @@ class PluginPlayer(App):
         :return: The built Kivy application
         :rtype: kivy.app.App
         """
-        
+
         self.popup = Popup()
 
         #The app's module manager

--- a/src/pluginplayer/tree_manager.py
+++ b/src/pluginplayer/tree_manager.py
@@ -38,6 +38,7 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.label import Label
 from kivy.uix.widget import Widget
 from kivy.graphics import Color, Rectangle
+from kivy.metrics import dp
 
 
 class TreeManager():
@@ -52,6 +53,37 @@ class TreeManager():
         """
         self.plugin_player = plugin_player
         self.saved_outputs = []
+        self.tree_section_widget = None
+        self.submodule_tree_layout = None
+    
+    def view_submodule_tree(self, instance):
+        """Reads the module manager, iterating through the submodules for the instance's module.
+        A structured tree is then created, making a heiarchy to configure submodules.
+
+        :param instance: The button pressed to view a node's submodule tree
+        :type instance: kivy.uix.button.Button
+        """
+        self.submodule_tree_layout = BoxLayout(orientation="vertical")
+        self.submodule_tree_layout.add_widget(Label(text="This is the submodule tree configuration", font_size='20sp',
+                            color=(0, 0, 0, 1)))
+        back_button = Button(text="Exit", on_press=self.view_module_tree)
+        self.submodule_tree_layout.add_widget(back_button)
+        right_section = self.plugin_player.root.ids.right_section
+        self.tree_section_widget = self.plugin_player.root.ids.right_section.ids.tree_section
+        right_section.remove_widget(self.tree_section_widget)
+        right_section.add_widget(self.submodule_tree_layout)
+    
+    def view_module_tree(self, instance):
+        """Modifies and prepares the inputs, outputs, and property types for non submodule nodes
+
+        :param instance: The back button from the view submodules tree
+        :type instance: kivy.uix.button.Button
+        """
+        right_section = self.plugin_player.root.ids.right_section
+        right_section.remove_widget(self.submodule_tree_layout)
+        right_section.add_widget(self.tree_section_widget)
+
+
 
     def delete_tree(self):
         """Delete the entire tree, its edges, and nodes.
@@ -85,7 +117,7 @@ class TreeManager():
 
         #create main widget
         node_widget = DraggableWidget(size_hint=(None, None),
-                                      size=(120, 80),
+                                      size=(dp(120), dp(80)),
                                       orientation='vertical',
                                       spacing=0)
         #set the relative window
@@ -104,8 +136,8 @@ class TreeManager():
         #add module name label
         widget_label = Label(
             size_hint=(None, None),
-            width=100,
-            height=80,
+            width=dp(100),
+            height=dp(80),
             halign='center',
             valign='center',
             text=f"{module_name} ({len(self.plugin_player.nodes)})")
@@ -115,15 +147,15 @@ class TreeManager():
         #add box for option buttons
         options = BoxLayout(orientation='vertical',
                             size_hint=(None, None),
-                            width=20,
-                            height=80,
-                            spacing=0)
+                            width=dp(20),
+                            height=dp(80),
+                            spacing=dp(0))
 
-        options.add_widget(Widget(size_hint_y=None, height=10))
+        options.add_widget(Widget(size_hint_y=None, height=dp(10)))
 
         self.plugin_player.create_image(
             'src/pluginplayer/assets/drag_icon.png',
-            'src/pluginplayer/assets/drag.png', (20, 20))
+            'src/pluginplayer/assets/drag.png', (int(dp(20)), int(dp(20))))
         navigate_button = DraggableImageButton(
             node_widget=node_widget,
             relative_window=self.plugin_player.root.ids.right_section.ids.
@@ -134,30 +166,30 @@ class TreeManager():
 
         self.plugin_player.create_image(
             'src/pluginplayer/assets/info_icon.png',
-            'src/pluginplayer/assets/info.png', (20, 20))
+            'src/pluginplayer/assets/info.png', (int(dp(20)), int(dp(20))))
 
         info_button = Button(
             background_normal='src/pluginplayer/assets/info.png',
             on_press=self.plugin_player.plugin_manager.view_module_info,
             size_hint_y=None,
-            height=20)
+            height=dp(20))
         #add id for module number, plugin number, and 1 (accessed in treeview)
         info_button.id = f'{module_number} {plugin_number} 1'
         options.add_widget(info_button)
 
         self.plugin_player.create_image(
             'src/pluginplayer/assets/remove_icon.png',
-            'src/pluginplayer/assets/remove.png', (20, 20))
+            'src/pluginplayer/assets/remove.png', (int(dp(20)), int(dp(20))))
 
         remove_button = Button(
             background_normal='src/pluginplayer/assets/remove.png',
             on_press=self.remove_node,
             size_hint_y=None,
-            height=20)
+            height=dp(20))
         remove_button.id = f'{len(self.plugin_player.nodes)}'
         options.add_widget(remove_button)
 
-        options.add_widget(Widget(size_hint_y=None, height=10))
+        options.add_widget(Widget(size_hint_y=None, height=dp(10)))
 
         basis_box.add_widget(options)
         node_widget.add_widget(basis_box)
@@ -165,14 +197,30 @@ class TreeManager():
         #add configure button
         config_button = Button(
             size_hint=(None, None),
-            height=20,
-            width=90,
-            valign='center',
+            height=dp(20),
+            width=dp(90),
+            halign='center',
             text='Configure',
             on_press=self.plugin_player.node_widget_manager.view_config)
         config_button.id = f'{len(self.plugin_player.nodes)}'
-        node_widget.height += 20
+        node_widget.height += dp(20)
         node_widget.add_widget(config_button)
+
+        #if the module has a submodule, add the option to view it in the submodule tree view
+        if(len(new_node.submod_dict) > 0):
+            submod_tree_button = Button(
+            size_hint=(None, None),
+            height=dp(20),
+            width=dp(90),
+            halign='center',
+            text='Submodules',
+            on_press=self.view_submodule_tree)
+            submod_tree_button.id = f'{len(self.plugin_player.nodes)}'
+            node_widget.height += dp(20)
+            node_widget.add_widget(submod_tree_button)
+
+
+        
         #add it to the screen and the main lists
         node_widget.pos = (1, 1)
         self.plugin_player.root.ids.right_section.ids.tree_section.add_widget(

--- a/src/pluginplayer/tree_manager.py
+++ b/src/pluginplayer/tree_manager.py
@@ -51,7 +51,6 @@ class TreeManager():
         self.plugin_player = plugin_player
         self.saved_outputs = []
 
-
     def delete_tree(self):
         """Delete the entire tree, its edges, and nodes.
         """

--- a/src/pluginplayer/tree_manager.py
+++ b/src/pluginplayer/tree_manager.py
@@ -55,7 +55,7 @@ class TreeManager():
         self.saved_outputs = []
         self.tree_section_widget = None
         self.submodule_tree_layout = None
-    
+
     def view_submodule_tree(self, instance):
         """Reads the module manager, iterating through the submodules for the instance's module.
         A structured tree is then created, making a heiarchy to configure submodules.
@@ -64,15 +64,17 @@ class TreeManager():
         :type instance: kivy.uix.button.Button
         """
         self.submodule_tree_layout = BoxLayout(orientation="vertical")
-        self.submodule_tree_layout.add_widget(Label(text="This is the submodule tree configuration", font_size='20sp',
-                            color=(0, 0, 0, 1)))
+        self.submodule_tree_layout.add_widget(
+            Label(text="This is the submodule tree configuration",
+                  font_size='20sp',
+                  color=(0, 0, 0, 1)))
         back_button = Button(text="Exit", on_press=self.view_module_tree)
         self.submodule_tree_layout.add_widget(back_button)
         right_section = self.plugin_player.root.ids.right_section
         self.tree_section_widget = self.plugin_player.root.ids.right_section.ids.tree_section
         right_section.remove_widget(self.tree_section_widget)
         right_section.add_widget(self.submodule_tree_layout)
-    
+
     def view_module_tree(self, instance):
         """Modifies and prepares the inputs, outputs, and property types for non submodule nodes
 
@@ -82,8 +84,6 @@ class TreeManager():
         right_section = self.plugin_player.root.ids.right_section
         right_section.remove_widget(self.submodule_tree_layout)
         right_section.add_widget(self.tree_section_widget)
-
-
 
     def delete_tree(self):
         """Delete the entire tree, its edges, and nodes.
@@ -207,20 +207,17 @@ class TreeManager():
         node_widget.add_widget(config_button)
 
         #if the module has a submodule, add the option to view it in the submodule tree view
-        if(len(new_node.submod_dict) > 0):
-            submod_tree_button = Button(
-            size_hint=(None, None),
-            height=dp(20),
-            width=dp(90),
-            halign='center',
-            text='Submodules',
-            on_press=self.view_submodule_tree)
+        if (len(new_node.submod_dict) > 0):
+            submod_tree_button = Button(size_hint=(None, None),
+                                        height=dp(20),
+                                        width=dp(90),
+                                        halign='center',
+                                        text='Submodules',
+                                        on_press=self.view_submodule_tree)
             submod_tree_button.id = f'{len(self.plugin_player.nodes)}'
             node_widget.height += dp(20)
             node_widget.add_widget(submod_tree_button)
 
-
-        
         #add it to the screen and the main lists
         node_widget.pos = (1, 1)
         self.plugin_player.root.ids.right_section.ids.tree_section.add_widget(

--- a/src/pluginplayer/tree_manager.py
+++ b/src/pluginplayer/tree_manager.py
@@ -49,6 +49,8 @@ class TreeManager():
         :type plugin_player: PluginPlayer
         """
         self.plugin_player = plugin_player
+        self.saved_outputs = []
+
 
     def delete_tree(self):
         """Delete the entire tree, its edges, and nodes.
@@ -340,9 +342,9 @@ class TreeManager():
         self.plugin_player.add_message(run_order)
 
         #set up the array for saving ouputs
-        saved_outputs = []
+        self.saved_outputs = []
         for i in range(len(run_order)):
-            saved_outputs.append([])
+            self.saved_outputs.append([])
 
         #run each node
         for run_node in dfs_result:
@@ -384,7 +386,7 @@ class TreeManager():
                 self.plugin_player.add_message(
                     f"{run_node.module_name}({nodes.index(run_node)}) Output: {output}"
                 )
-                saved_outputs[nodes.index(run_node)].append(output)
+                self.saved_outputs[nodes.index(run_node)].append(output)
             except Exception as e:
                 self.plugin_player.add_message(
                     f"Could not run {run_node.module_name}({nodes.index(run_node)}): {e}"

--- a/src/pluginplayer/tree_manager.py
+++ b/src/pluginplayer/tree_manager.py
@@ -28,7 +28,9 @@ Deleting the tree
 """
 
 #helper widget classes for a draggable widget representing a module
-from node_widget import DraggableImageButton, DraggableWidget, ModuleNode
+from pluginplayer.node_widget import DraggableImageButton
+from pluginplayer.node_widget import DraggableWidget
+from pluginplayer.node_widget import ModuleNode
 
 #kivy helpers
 from kivy.uix.button import Button

--- a/src/pluginplayer/utility_manager.py
+++ b/src/pluginplayer/utility_manager.py
@@ -50,9 +50,10 @@ class UtilityManager():
         """Initialization of the UtilityManager class
         """
         self.imported_classes = []
-        self.custom_declaration_widget = TextInput(hint_text="from _____ import _____",
-                                   multiline=False,
-                                   size_hint_x=9 / 10)
+        self.custom_declaration_widget = TextInput(
+            hint_text="from _____ import _____",
+            multiline=False,
+            size_hint_x=9 / 10)
 
     def browse(self, plugin_player):
         """Browse for a new file from the file system and place in entry box
@@ -134,9 +135,10 @@ class UtilityManager():
                              size_hint_y=None,
                              height=35,
                              spacing=0)
-        
+
         if self.custom_declaration_widget.parent:
-            self.custom_declaration_widget.parent.remove_widget(self.custom_declaration_widget)
+            self.custom_declaration_widget.parent.remove_widget(
+                self.custom_declaration_widget)
         new_type.add_widget(self.custom_declaration_widget)
 
         #add an import button

--- a/src/pluginplayer/utility_manager.py
+++ b/src/pluginplayer/utility_manager.py
@@ -50,6 +50,9 @@ class UtilityManager():
         """Initialization of the UtilityManager class
         """
         self.imported_classes = []
+        self.custom_declaration_widget = TextInput(hint_text="from _____ import _____",
+                                   multiline=False,
+                                   size_hint_x=9 / 10)
 
     def browse(self, plugin_player):
         """Browse for a new file from the file system and place in entry box
@@ -131,13 +134,10 @@ class UtilityManager():
                              size_hint_y=None,
                              height=35,
                              spacing=0)
-        new_type_entry = TextInput(hint_text="from _____ import _____",
-                                   multiline=False,
-                                   size_hint_x=9 / 10)
-        new_type.add_widget(new_type_entry)
-
-        #set as global to pull from it when its submitted
-        self.custom_declaration_widget = new_type_entry
+        
+        if self.custom_declaration_widget.parent:
+            self.custom_declaration_widget.parent.remove_widget(self.custom_declaration_widget)
+        new_type.add_widget(self.custom_declaration_widget)
 
         #add an import button
         add_button = Button(text="Import",

--- a/tests/pluginplayer_shell.py
+++ b/tests/pluginplayer_shell.py
@@ -1,3 +1,17 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #pluginplay helpers
 import pluginplay as pp
 import pluginplay_examples as ppe
@@ -6,10 +20,8 @@ from unittest.mock import MagicMock
 from plugin_player import PluginPlayer
 
 
-
-
-
 class PluginPlayerShell:
+
     def get_shell(self):
 
         #create an instance of the player
@@ -33,4 +45,3 @@ class PluginPlayerShell:
 
         #return the instance
         return player
-    

--- a/tests/pluginplayer_shell.py
+++ b/tests/pluginplayer_shell.py
@@ -33,14 +33,12 @@ from kivy.uix.popup import Popup
 from kivy.uix.image import Image
 
 
-
 class PluginPlayerShell:
     """The class representing the connecting helper class 
     components of PluginPlayer without triggering Kivy window production
     """
 
     def __init__(self):
-
         """Initializes the helpers and instance variables for the PluginPlayer class for testing
         """
         self.popup = Popup()

--- a/tests/pluginplayer_shell.py
+++ b/tests/pluginplayer_shell.py
@@ -1,0 +1,36 @@
+#pluginplay helpers
+import pluginplay as pp
+import pluginplay_examples as ppe
+from plugin_manager import PluginInfo
+from unittest.mock import MagicMock
+from plugin_player import PluginPlayer
+
+
+
+
+
+class PluginPlayerShell:
+    def get_shell(self):
+
+        #create an instance of the player
+        player = PluginPlayer()
+        player.test_setup()
+
+        #mock the visual functions
+        player.add_message = MagicMock()
+        player.plugin_manager.plugin_view = MagicMock()
+        player.create_image = MagicMock()
+        player.create_popup = MagicMock()
+        player.root = MagicMock()
+
+        #load the example modules into the plugin manually through instance variables
+        ppe.load_modules(player.mm)
+
+        #add it to the list of modules
+        new_plugin = PluginInfo(plugin_name="pluginplay_examples",
+                                modules=player.mm.keys())
+        player.plugin_manager.saved_plugins.append(new_plugin)
+
+        #return the instance
+        return player
+    

--- a/tests/pluginplayer_shell.py
+++ b/tests/pluginplayer_shell.py
@@ -15,9 +15,9 @@
 #pluginplay helpers
 import pluginplay as pp
 import pluginplay_examples as ppe
-from plugin_manager import PluginInfo
+from pluginplayer.plugin_manager import PluginInfo
+from pluginplayer.plugin_player import PluginPlayer
 from unittest.mock import MagicMock
-from plugin_player import PluginPlayer
 
 
 class PluginPlayerShell:

--- a/tests/pluginplayer_shell.py
+++ b/tests/pluginplayer_shell.py
@@ -19,29 +19,64 @@ from pluginplayer.plugin_manager import PluginInfo
 from pluginplayer.plugin_player import PluginPlayer
 from unittest.mock import MagicMock
 
+#helper classes for a PluginPlayer interface
+from pluginplayer.plugin_manager import PluginManager
+from pluginplayer.tree_manager import TreeManager
+from pluginplayer.node_widget_manager import NodeWidgetManager
+from pluginplayer.node_manager import NodeManager
+from pluginplayer.utility_manager import UtilityManager
+
+#kivy helpers
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.uix.popup import Popup
+from kivy.uix.image import Image
+
+
 
 class PluginPlayerShell:
+    """The class representing the connecting helper class 
+    components of PluginPlayer without triggering Kivy window production
+    """
 
-    def get_shell(self):
+    def __init__(self):
 
-        #create an instance of the player
-        player = PluginPlayer()
-        player.test_setup()
+        """Initializes the helpers and instance variables for the PluginPlayer class for testing
+        """
+        self.popup = Popup()
+
+        #The app's module manager
+        self.mm = pp.ModuleManager()
+
+        #saved tree containing the nodes and modules to be ran
+        self.nodes = []
+
+        #helper class handling addition/removal of nodes, deleting/running the tree
+        self.tree_manager = TreeManager(self)
+
+        #helper class handling the widget building for the node configuration
+        self.node_widget_manager = NodeWidgetManager(self)
+
+        #helper class handling the linking of inputs, submods, property types between modules
+        self.node_manager = NodeManager(self)
+
+        #helper class handling the loading, deleting, and viewing of plugins and their modules
+        self.plugin_manager = PluginManager(self)
+
+        #helper class handling browsing, imported class types, and importing new classes
+        self.utility_manager = UtilityManager()
 
         #mock the visual functions
-        player.add_message = MagicMock()
-        player.plugin_manager.plugin_view = MagicMock()
-        player.create_image = MagicMock()
-        player.create_popup = MagicMock()
-        player.root = MagicMock()
+        self.add_message = MagicMock()
+        self.plugin_manager.plugin_view = MagicMock()
+        self.create_image = MagicMock()
+        self.create_popup = MagicMock()
+        self.root = MagicMock()
 
         #load the example modules into the plugin manually through instance variables
-        ppe.load_modules(player.mm)
+        ppe.load_modules(self.mm)
 
         #add it to the list of modules
         new_plugin = PluginInfo(plugin_name="pluginplay_examples",
-                                modules=player.mm.keys())
-        player.plugin_manager.saved_plugins.append(new_plugin)
-
-        #return the instance
-        return player
+                                modules=self.mm.keys())
+        self.plugin_manager.saved_plugins.append(new_plugin)

--- a/tests/test_nodemanager.py
+++ b/tests/test_nodemanager.py
@@ -1,3 +1,17 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #stop automatic kivy methods
 from kivy.config import Config
 # Set Kivy to dummy backend to prevent window creation
@@ -11,9 +25,11 @@ from pluginplayer_shell import PluginPlayerShell
 from kivy.uix.button import Button
 
 #pluginplay_examples
-from pluginplay_examples import Force 
+from pluginplay_examples import Force
+
 
 class TestNodeManager(unittest.TestCase):
+
     def test_link_input(self):
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
@@ -38,28 +54,40 @@ class TestNodeManager(unittest.TestCase):
         player.node_manager.link_input(moduleButton)
 
         #check if the inputs and outputs are set
-        self.assertEquals(player.nodes[1].output_map[0], [(2, 0)], "The node's output map was not set correctly")
-        self.assertEquals(player.nodes[1].input_map[0], (0,0), "The node's input map was not set correctly")
-        self.assertEquals(player.nodes[0].output_map[0], [(1,0)], "The node's output map was not set correctly")
-        self.assertEquals(player.nodes[2].input_map[0], (1,0), "The node's input map was not set correctly")
+        self.assertEquals(player.nodes[1].output_map[0], [(2, 0)],
+                          "The node's output map was not set correctly")
+        self.assertEquals(player.nodes[1].input_map[0], (0, 0),
+                          "The node's input map was not set correctly")
+        self.assertEquals(player.nodes[0].output_map[0], [(1, 0)],
+                          "The node's output map was not set correctly")
+        self.assertEquals(player.nodes[2].input_map[0], (1, 0),
+                          "The node's input map was not set correctly")
 
         #link the first output of the second node to the second input of the third node
         moduleButton.id = '1 0 2 1'
         player.node_manager.link_input(moduleButton)
 
         #check that the output is mapped to two places
-        self.assertEquals(player.nodes[1].output_map[0], [(2, 0), (2, 1)], "The node's second output was not tracked in the output map")
-        self.assertEquals(player.nodes[2].input_map[1], (1,0), "The node's input map was not set correctly")
+        self.assertEquals(
+            player.nodes[1].output_map[0], [(2, 0), (2, 1)],
+            "The node's second output was not tracked in the output map")
+        self.assertEquals(player.nodes[2].input_map[1], (1, 0),
+                          "The node's input map was not set correctly")
 
         #change the first input of the third node, to map from the first output of the first node
         moduleButton.id = '0 0 2 0'
         player.node_manager.link_input(moduleButton)
 
         #check that the new and previous output and inputs are correctly editted
-        self.assertEquals(player.nodes[0].output_map[0], [(1,0), (2, 0)], "The node's output map was not correctly editted")
-        self.assertEquals(player.nodes[1].output_map[0], [(2, 1)], "The node's output was correctly editted after a replacement")
-        self.assertEquals(player.nodes[2].input_map[0], (0,0), "The node's input map was not set after a replacement")
-    
+        self.assertEquals(player.nodes[0].output_map[0], [(1, 0), (2, 0)],
+                          "The node's output map was not correctly editted")
+        self.assertEquals(
+            player.nodes[1].output_map[0], [(2, 1)],
+            "The node's output was correctly editted after a replacement")
+        self.assertEquals(
+            player.nodes[2].input_map[0], (0, 0),
+            "The node's input map was not set after a replacement")
+
     def test_link_property_type(self):
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
@@ -69,13 +97,12 @@ class TestNodeManager(unittest.TestCase):
         moduleButton.id = '0 0'
         player.tree_manager.add_node(moduleButton)
 
-
         #set the id for the back button
         backButton = Button()
         backButton.id = '0 0'
 
         player.utility_manager.custom_declaration_widget.text = 'pluginplay_examples Force'
-        
+
         #call the new_type function to add it to the list of types
         player.utility_manager.new_type(backButton, player)
 
@@ -85,9 +112,9 @@ class TestNodeManager(unittest.TestCase):
         #link the property type
         moduleButton.id = '0'
         player.node_manager.link_property_type(moduleButton)
-        
 
-        self.assertNotEquals(player.nodes[0].property_type, None, "Property Type was not set")
+        self.assertNotEquals(player.nodes[0].property_type, None,
+                             "Property Type was not set")
 
     def test_link_submod(self):
 
@@ -101,10 +128,7 @@ class TestNodeManager(unittest.TestCase):
 
         moduleButton.id = '0 0 0 3'
         player.node_manager.link_submod(moduleButton)
-    
 
 
 if __name__ == "__main__":
     unittest.main()
-
-

--- a/tests/test_nodemanager.py
+++ b/tests/test_nodemanager.py
@@ -32,7 +32,7 @@ class TestNodeManager(unittest.TestCase):
 
     def test_link_input(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add new nodes with instances routing to the first, second, and third module from the first plugin
         moduleButton = Button()
@@ -90,7 +90,7 @@ class TestNodeManager(unittest.TestCase):
 
     def test_link_property_type(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add a node
         moduleButton = Button()
@@ -119,7 +119,7 @@ class TestNodeManager(unittest.TestCase):
     def test_link_submod(self):
 
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add a node
         moduleButton = Button()

--- a/tests/test_nodemanager.py
+++ b/tests/test_nodemanager.py
@@ -1,0 +1,110 @@
+#stop automatic kivy methods
+from kivy.config import Config
+# Set Kivy to dummy backend to prevent window creation
+Config.set('graphics', 'backend', 'dummy')
+
+# test_pluginplayer.py
+import unittest
+from pluginplayer_shell import PluginPlayerShell
+
+#kivy button for instance
+from kivy.uix.button import Button
+
+#pluginplay_examples
+from pluginplay_examples import Force 
+
+class TestNodeManager(unittest.TestCase):
+    def test_link_input(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add new nodes with instances routing to the first, second, and third module from the first plugin
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '1 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '2 0'
+        player.tree_manager.add_node(moduleButton)
+
+        #link the output of the first node to the first input of the second node
+        moduleButton.id = '0 0 1 0'
+        player.node_manager.link_input(moduleButton)
+
+        #link the output of the second node to the first input of the third node
+        moduleButton.id = '1 0 2 0'
+        player.node_manager.link_input(moduleButton)
+
+        #check if the inputs and outputs are set
+        self.assertEquals(player.nodes[1].output_map[0], [(2, 0)], "The node's output map was not set correctly")
+        self.assertEquals(player.nodes[1].input_map[0], (0,0), "The node's input map was not set correctly")
+        self.assertEquals(player.nodes[0].output_map[0], [(1,0)], "The node's output map was not set correctly")
+        self.assertEquals(player.nodes[2].input_map[0], (1,0), "The node's input map was not set correctly")
+
+        #link the first output of the second node to the second input of the third node
+        moduleButton.id = '1 0 2 1'
+        player.node_manager.link_input(moduleButton)
+
+        #check that the output is mapped to two places
+        self.assertEquals(player.nodes[1].output_map[0], [(2, 0), (2, 1)], "The node's second output was not tracked in the output map")
+        self.assertEquals(player.nodes[2].input_map[1], (1,0), "The node's input map was not set correctly")
+
+        #change the first input of the third node, to map from the first output of the first node
+        moduleButton.id = '0 0 2 0'
+        player.node_manager.link_input(moduleButton)
+
+        #check that the new and previous output and inputs are correctly editted
+        self.assertEquals(player.nodes[0].output_map[0], [(1,0), (2, 0)], "The node's output map was not correctly editted")
+        self.assertEquals(player.nodes[1].output_map[0], [(2, 1)], "The node's output was correctly editted after a replacement")
+        self.assertEquals(player.nodes[2].input_map[0], (0,0), "The node's input map was not set after a replacement")
+    
+    def test_link_property_type(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add a node
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+
+        #set the id for the back button
+        backButton = Button()
+        backButton.id = '0 0'
+
+        player.utility_manager.custom_declaration_widget.text = 'pluginplay_examples Force'
+        
+        #call the new_type function to add it to the list of types
+        player.utility_manager.new_type(backButton, player)
+
+        #enter Force() into the entry widget
+        player.nodes[0].custom_declaration_widget.text = "Force()"
+
+        #link the property type
+        moduleButton.id = '0'
+        player.node_manager.link_property_type(moduleButton)
+        
+
+        self.assertNotEquals(player.nodes[0].property_type, None, "Property Type was not set")
+
+    def test_link_submod(self):
+
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add a node
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '0 0 0 3'
+        player.node_manager.link_submod(moduleButton)
+    
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+

--- a/tests/test_pluginmanager.py
+++ b/tests/test_pluginmanager.py
@@ -1,3 +1,17 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #stop automatic kivy methods
 from kivy.config import Config
 # Set Kivy to dummy backend to prevent window creation
@@ -10,14 +24,20 @@ from pluginplayer_shell import PluginPlayerShell
 #kivy button for instance
 from kivy.uix.button import Button
 
+
 class TestPluginManager(unittest.TestCase):
+
     def test_plugin_import_from_shell(self):
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
 
         #check if plugin is loaded
-        self.assertNotEqual(player.plugin_manager.saved_plugins[0], None, "Failed to import pluginplay examples through test shell")
-        self.assertEqual(len(player.plugin_manager.saved_plugins), 1, "Failed to import pluginplay examples through test shell")
+        self.assertNotEqual(
+            player.plugin_manager.saved_plugins[0], None,
+            "Failed to import pluginplay examples through test shell")
+        self.assertEqual(
+            len(player.plugin_manager.saved_plugins), 1,
+            "Failed to import pluginplay examples through test shell")
 
     def test_delete_plugins(self):
         #get a new shell
@@ -29,7 +49,9 @@ class TestPluginManager(unittest.TestCase):
         player.plugin_manager.delete_plugin(deleteButton)
 
         #attempt to delete the first plugin
-        self.assertEqual(player.plugin_manager.saved_plugins[0], None, "Failed to set the imported plugin to None after deletion")
+        self.assertEqual(
+            player.plugin_manager.saved_plugins[0], None,
+            "Failed to set the imported plugin to None after deletion")
         self.assertEqual(player.nodes, [])
 
         #get a new shell
@@ -39,12 +61,18 @@ class TestPluginManager(unittest.TestCase):
         moduleButton = Button()
         moduleButton.id = '0 0'
         player.tree_manager.add_node(moduleButton)
-        
+
         #delete the plugin, which should delete all plugin's nodes as well
         player.plugin_manager.delete_plugin(deleteButton)
 
-        self.assertEqual(player.plugin_manager.saved_plugins[0], None, "Failed to set the imported plugin to None after deletion")
-        self.assertEqual(player.nodes[0], None, "Failed to set a plugin's nodes to None after the plugin's deletion")
+        self.assertEqual(
+            player.plugin_manager.saved_plugins[0], None,
+            "Failed to set the imported plugin to None after deletion")
+        self.assertEqual(
+            player.nodes[0], None,
+            "Failed to set a plugin's nodes to None after the plugin's deletion"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pluginmanager.py
+++ b/tests/test_pluginmanager.py
@@ -1,0 +1,50 @@
+#stop automatic kivy methods
+from kivy.config import Config
+# Set Kivy to dummy backend to prevent window creation
+Config.set('graphics', 'backend', 'dummy')
+
+# test_pluginplayer.py
+import unittest
+from pluginplayer_shell import PluginPlayerShell
+
+#kivy button for instance
+from kivy.uix.button import Button
+
+class TestPluginManager(unittest.TestCase):
+    def test_plugin_import_from_shell(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #check if plugin is loaded
+        self.assertNotEqual(player.plugin_manager.saved_plugins[0], None, "Failed to import pluginplay examples through test shell")
+        self.assertEqual(len(player.plugin_manager.saved_plugins), 1, "Failed to import pluginplay examples through test shell")
+
+    def test_delete_plugins(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #Create button instance to delete the first plugin
+        deleteButton = Button()
+        deleteButton.id = '0'
+        player.plugin_manager.delete_plugin(deleteButton)
+
+        #attempt to delete the first plugin
+        self.assertEqual(player.plugin_manager.saved_plugins[0], None, "Failed to set the imported plugin to None after deletion")
+        self.assertEqual(player.nodes, [])
+
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add a new node with instance routing to the first module from the first plugin
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+        
+        #delete the plugin, which should delete all plugin's nodes as well
+        player.plugin_manager.delete_plugin(deleteButton)
+
+        self.assertEqual(player.plugin_manager.saved_plugins[0], None, "Failed to set the imported plugin to None after deletion")
+        self.assertEqual(player.nodes[0], None, "Failed to set a plugin's nodes to None after the plugin's deletion")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pluginmanager.py
+++ b/tests/test_pluginmanager.py
@@ -29,7 +29,7 @@ class TestPluginManager(unittest.TestCase):
 
     def test_plugin_import_from_shell(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #check if plugin is loaded
         self.assertNotEqual(
@@ -41,7 +41,7 @@ class TestPluginManager(unittest.TestCase):
 
     def test_delete_plugins(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #Create button instance to delete the first plugin
         deleteButton = Button()
@@ -55,7 +55,7 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(player.nodes, [])
 
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add a new node with instance routing to the first module from the first plugin
         moduleButton = Button()

--- a/tests/test_pluginplayer.py
+++ b/tests/test_pluginplayer.py
@@ -19,9 +19,6 @@ import parallelzone as pz
 import sys
 import unittest
 
-
-
-
 if __name__ == '__main__':
     rv = pz.runtime.RuntimeView()
 

--- a/tests/test_pluginplayer.py
+++ b/tests/test_pluginplayer.py
@@ -23,8 +23,9 @@ if __name__ == '__main__':
     rv = pz.runtime.RuntimeView()
 
     my_dir = os.path.dirname(os.path.realpath(__file__))
-    root_dir = os.path.dirname(os.path.dirname(os.path.dirname(my_dir)))
-    src_dir = os.path.join(root_dir, 'tests')
+    root_dir = os.path.dirname(my_dir)
+    src_dir = os.path.join(root_dir, 'src')
+    print(src_dir)
     sys.path.append(src_dir)
 
     loader = unittest.TestLoader()

--- a/tests/test_pluginplayer.py
+++ b/tests/test_pluginplayer.py
@@ -25,7 +25,6 @@ if __name__ == '__main__':
     my_dir = os.path.dirname(os.path.realpath(__file__))
     root_dir = os.path.dirname(my_dir)
     src_dir = os.path.join(root_dir, 'src')
-    print(src_dir)
     sys.path.append(src_dir)
 
     loader = unittest.TestLoader()

--- a/tests/test_pluginplayer.py
+++ b/tests/test_pluginplayer.py
@@ -1,0 +1,37 @@
+#
+# Copyright 2023 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import parallelzone as pz
+import sys
+import unittest
+
+
+
+
+if __name__ == '__main__':
+    rv = pz.runtime.RuntimeView()
+
+    my_dir = os.path.dirname(os.path.realpath(__file__))
+    root_dir = os.path.dirname(os.path.dirname(os.path.dirname(my_dir)))
+    src_dir = os.path.join(root_dir, 'tests')
+    sys.path.append(src_dir)
+
+    loader = unittest.TestLoader()
+    tests = loader.discover(my_dir)
+    testrunner = unittest.runner.TextTestRunner()
+    ret = not testrunner.run(tests).wasSuccessful()
+    sys.exit(ret)

--- a/tests/test_treemanager.py
+++ b/tests/test_treemanager.py
@@ -1,3 +1,17 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #stop automatic kivy methods
 from kivy.config import Config
 # Set Kivy to dummy backend to prevent window creation
@@ -15,7 +29,9 @@ import pluginplay as pp
 import pluginplay_examples as ppe
 from pluginplay_examples import PointCharge, ElectricField, Force
 
+
 class TestTreeManager(unittest.TestCase):
+
     def test_add_node(self):
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
@@ -26,7 +42,8 @@ class TestTreeManager(unittest.TestCase):
         player.tree_manager.add_node(moduleButton)
 
         #check to see a node was added
-        self.assertEquals(len(player.nodes), 1, "No node was added to tree section")
+        self.assertEquals(len(player.nodes), 1,
+                          "No node was added to tree section")
 
     def test_delete_node(self):
         #get a new shell
@@ -41,7 +58,8 @@ class TestTreeManager(unittest.TestCase):
         player.tree_manager.remove_node(moduleButton)
 
         #check to see a node was deleted
-        self.assertEquals(player.nodes[0], None, "The Node was not set to None after deletion")
+        self.assertEquals(player.nodes[0], None,
+                          "The Node was not set to None after deletion")
 
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
@@ -69,10 +87,15 @@ class TestTreeManager(unittest.TestCase):
         player.tree_manager.remove_node(moduleButton)
 
         #check to see if second node was deleted, the output link of the first node was removed, the input link of the third node was removed
-        self.assertEquals(player.nodes[1], None, "The Node was not set to None after deletion")
-        self.assertEquals(player.nodes[0].output_map[0], [], "Output link still exists after its linking node was deleted")
-        self.assertEquals(player.nodes[2].input_map[0], None, "Input link still exists after its linking node was deleted")
-    
+        self.assertEquals(player.nodes[1], None,
+                          "The Node was not set to None after deletion")
+        self.assertEquals(
+            player.nodes[0].output_map[0], [],
+            "Output link still exists after its linking node was deleted")
+        self.assertEquals(
+            player.nodes[2].input_map[0], None,
+            "Input link still exists after its linking node was deleted")
+
     def test_delete_tree(self):
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
@@ -94,12 +117,13 @@ class TestTreeManager(unittest.TestCase):
         #remove all nodes in the tree
         player.tree_manager.delete_tree()
 
-        self.assertEquals(player.nodes, [], "There still exists nodes after tree deletion")
+        self.assertEquals(player.nodes, [],
+                          "There still exists nodes after tree deletion")
 
     def test_run_tree(self):
         mm = pp.ModuleManager()
         ppe.load_modules(mm)
-        
+
         force0_mod = mm.at("Classical Force")
         force1_mod = mm.at("Coulomb's Law")
         force2_mod = mm.at("Single-precision Coulomb's law")
@@ -156,7 +180,8 @@ class TestTreeManager(unittest.TestCase):
 
         #---------------------FORCE NODE--------------------------
         moduleButton.id = '-1 0 0 0'
-        player.nodes[0].custom_declaration_widget.text = 'PointCharge( 1.0, [0.0, 0.0, 0.0])'
+        player.nodes[
+            0].custom_declaration_widget.text = 'PointCharge( 1.0, [0.0, 0.0, 0.0])'
         player.node_manager.link_input(moduleButton)
 
         moduleButton.id = '-1 0 0 1'
@@ -168,7 +193,8 @@ class TestTreeManager(unittest.TestCase):
         player.node_manager.link_input(moduleButton)
 
         moduleButton.id = '-1 0 0 0'
-        player.nodes[0].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
+        player.nodes[
+            0].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
         player.node_manager.link_input(moduleButton)
 
         moduleButton.id = '0 0 0 3'
@@ -187,7 +213,8 @@ class TestTreeManager(unittest.TestCase):
         player.node_manager.link_input(moduleButton)
 
         moduleButton.id = '-1 0 1 1'
-        player.nodes[1].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
+        player.nodes[
+            1].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
         player.node_manager.link_input(moduleButton)
 
         #enter PointCharge() into the entry widget
@@ -203,7 +230,8 @@ class TestTreeManager(unittest.TestCase):
         player.node_manager.link_input(moduleButton)
 
         moduleButton.id = '-1 0 2 1'
-        player.nodes[2].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
+        player.nodes[
+            2].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
         player.node_manager.link_input(moduleButton)
 
         #enter PointCharge() into the entry widget
@@ -213,26 +241,17 @@ class TestTreeManager(unittest.TestCase):
         moduleButton.id = '1'
         player.node_manager.link_property_type(moduleButton)
 
-
-
         #Run the tree
         player.tree_manager.run_tree()
 
         #Check if the values are the same
-        self.assertEquals(result0, player.tree_manager.saved_outputs[0], "Module output did not ran as expected")
-        self.assertEquals(result1, player.tree_manager.saved_outputs[1], "Module output did not ran as expected")
-        self.assertEquals(result2, player.tree_manager.saved_outputs[2], "Module output did not ran as expected")
-
-        
-
-
-
-
-
+        self.assertEquals(result0, player.tree_manager.saved_outputs[0],
+                          "Module output did not ran as expected")
+        self.assertEquals(result1, player.tree_manager.saved_outputs[1],
+                          "Module output did not ran as expected")
+        self.assertEquals(result2, player.tree_manager.saved_outputs[2],
+                          "Module output did not ran as expected")
 
 
 if __name__ == "__main__":
     unittest.main()
-
-        
-

--- a/tests/test_treemanager.py
+++ b/tests/test_treemanager.py
@@ -1,0 +1,238 @@
+#stop automatic kivy methods
+from kivy.config import Config
+# Set Kivy to dummy backend to prevent window creation
+Config.set('graphics', 'backend', 'dummy')
+
+# test_pluginplayer.py
+import unittest
+from pluginplayer_shell import PluginPlayerShell
+
+#kivy button for instance
+from kivy.uix.button import Button
+
+#pluginplay
+import pluginplay as pp
+import pluginplay_examples as ppe
+from pluginplay_examples import PointCharge, ElectricField, Force
+
+class TestTreeManager(unittest.TestCase):
+    def test_add_node(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add a new node with instance routing to the first module from the first plugin
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+        #check to see a node was added
+        self.assertEquals(len(player.nodes), 1, "No node was added to tree section")
+
+    def test_delete_node(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add a new node with instance routing to the first module from the first plugin
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '0'
+        player.tree_manager.remove_node(moduleButton)
+
+        #check to see a node was deleted
+        self.assertEquals(player.nodes[0], None, "The Node was not set to None after deletion")
+
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add new nodes with instances routing to the first, second, and third module from the first plugin
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '1 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '2 0'
+        player.tree_manager.add_node(moduleButton)
+
+        #link the output of the first node to the first input of the second node
+        moduleButton.id = '0 0 1 0'
+        player.node_manager.link_input(moduleButton)
+
+        #link the output of the second node to the first input of the third node
+        moduleButton.id = '1 0 2 0'
+        player.node_manager.link_input(moduleButton)
+
+        #delete the middle second node
+        moduleButton.id = '1'
+        player.tree_manager.remove_node(moduleButton)
+
+        #check to see if second node was deleted, the output link of the first node was removed, the input link of the third node was removed
+        self.assertEquals(player.nodes[1], None, "The Node was not set to None after deletion")
+        self.assertEquals(player.nodes[0].output_map[0], [], "Output link still exists after its linking node was deleted")
+        self.assertEquals(player.nodes[2].input_map[0], None, "Input link still exists after its linking node was deleted")
+    
+    def test_delete_tree(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add a new node with instance routing to the first module from the first plugin
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '1 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '2 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '3 0'
+        player.tree_manager.add_node(moduleButton)
+
+        #remove all nodes in the tree
+        player.tree_manager.delete_tree()
+
+        self.assertEquals(player.nodes, [], "There still exists nodes after tree deletion")
+
+    def test_run_tree(self):
+        mm = pp.ModuleManager()
+        ppe.load_modules(mm)
+        
+        force0_mod = mm.at("Classical Force")
+        force1_mod = mm.at("Coulomb's Law")
+        force2_mod = mm.at("Single-precision Coulomb's law")
+        force3_mod = mm.at("Coulomb's Law with screening")
+
+        p0 = [0.0, 0.0, 0.0]
+        p1 = [1.0, 0.0, 0.0]
+        p2 = [2.0, 0.0, 0.0]
+        r0 = [5.5, 0.0, 0.0]
+        r1 = [1.5, 0.0, 0.0]
+        pc0 = ppe.PointCharge(1.0, p0)
+        pc1 = ppe.PointCharge(1.0, p1)
+        pc2 = ppe.PointCharge(2.0, p2)
+        pcs = [pc1, pc2]
+        m1 = 2.0
+
+        force_pt = ppe.Force()
+        efield_pt = ppe.ElectricField()
+
+        result0 = force0_mod.run_as(force_pt, pc0, m1, p2, pcs)
+        result1 = force1_mod.run_as(efield_pt, p0, pcs)
+        result2 = force3_mod.run_as(efield_pt, p0, pcs)
+        #get player shell
+        player = PluginPlayerShell.get_shell(self)
+
+        #add one of each nodes to the tree
+        moduleButton = Button()
+        moduleButton.id = '0 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '1 0'
+        player.tree_manager.add_node(moduleButton)
+
+        moduleButton.id = '3 0'
+        player.tree_manager.add_node(moduleButton)
+
+        #add PointCharge and Force to the list of classes
+
+        backButton = Button()
+        backButton.id = '0 0'
+        player.utility_manager.custom_declaration_widget.text = 'pluginplay_examples PointCharge'
+        #call the new_type function to add it to the list of types
+        player.utility_manager.new_type(backButton, player)
+
+        player.utility_manager.custom_declaration_widget.text = 'pluginplay_examples Force'
+        #call the new_type function to add it to the list of types
+        player.utility_manager.new_type(backButton, player)
+
+        player.utility_manager.custom_declaration_widget.text = 'pluginplay_examples ElectricField'
+        #call the new_type function to add it to the list of types
+        player.utility_manager.new_type(backButton, player)
+
+        #add in the inputs, set the property types, and submodules
+
+        #---------------------FORCE NODE--------------------------
+        moduleButton.id = '-1 0 0 0'
+        player.nodes[0].custom_declaration_widget.text = 'PointCharge( 1.0, [0.0, 0.0, 0.0])'
+        player.node_manager.link_input(moduleButton)
+
+        moduleButton.id = '-1 0 0 1'
+        player.nodes[0].custom_declaration_widget.text = '2.0'
+        player.node_manager.link_input(moduleButton)
+
+        moduleButton.id = '-1 0 0 2'
+        player.nodes[0].custom_declaration_widget.text = '[2.0, 0.0, 0.0]'
+        player.node_manager.link_input(moduleButton)
+
+        moduleButton.id = '-1 0 0 0'
+        player.nodes[0].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
+        player.node_manager.link_input(moduleButton)
+
+        moduleButton.id = '0 0 0 3'
+        player.node_manager.link_submod(moduleButton)
+
+        #enter Force() into the entry widget
+        player.nodes[0].custom_declaration_widget.text = "Force()"
+
+        #link the property type
+        moduleButton.id = '0'
+        player.node_manager.link_property_type(moduleButton)
+
+        #-----------------Coloumb's law----------------
+        moduleButton.id = '-1 0 1 0'
+        player.nodes[1].custom_declaration_widget.text = '[0.0, 0.0, 0.0]'
+        player.node_manager.link_input(moduleButton)
+
+        moduleButton.id = '-1 0 1 1'
+        player.nodes[1].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
+        player.node_manager.link_input(moduleButton)
+
+        #enter PointCharge() into the entry widget
+        player.nodes[1].custom_declaration_widget.text = "ElectricField()"
+
+        #link the property type
+        moduleButton.id = '1'
+        player.node_manager.link_property_type(moduleButton)
+
+        #-----------------Coloumb's Single-Precesion----------------
+        moduleButton.id = '-1 0 2 0'
+        player.nodes[2].custom_declaration_widget.text = '[0.0, 0.0, 0.0]'
+        player.node_manager.link_input(moduleButton)
+
+        moduleButton.id = '-1 0 2 1'
+        player.nodes[2].custom_declaration_widget.text = '[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]'
+        player.node_manager.link_input(moduleButton)
+
+        #enter PointCharge() into the entry widget
+        player.nodes[2].custom_declaration_widget.text = "ElectricField()"
+
+        #link the property type
+        moduleButton.id = '1'
+        player.node_manager.link_property_type(moduleButton)
+
+
+
+        #Run the tree
+        player.tree_manager.run_tree()
+
+        #Check if the values are the same
+        self.assertEquals(result0, player.tree_manager.saved_outputs[0], "Module output did not ran as expected")
+        self.assertEquals(result1, player.tree_manager.saved_outputs[1], "Module output did not ran as expected")
+        self.assertEquals(result2, player.tree_manager.saved_outputs[2], "Module output did not ran as expected")
+
+        
+
+
+
+
+
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+        
+

--- a/tests/test_treemanager.py
+++ b/tests/test_treemanager.py
@@ -34,7 +34,7 @@ class TestTreeManager(unittest.TestCase):
 
     def test_add_node(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add a new node with instance routing to the first module from the first plugin
         moduleButton = Button()
@@ -47,7 +47,7 @@ class TestTreeManager(unittest.TestCase):
 
     def test_delete_node(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add a new node with instance routing to the first module from the first plugin
         moduleButton = Button()
@@ -62,7 +62,7 @@ class TestTreeManager(unittest.TestCase):
                           "The Node was not set to None after deletion")
 
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add new nodes with instances routing to the first, second, and third module from the first plugin
         moduleButton.id = '0 0'
@@ -98,7 +98,7 @@ class TestTreeManager(unittest.TestCase):
 
     def test_delete_tree(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add a new node with instance routing to the first module from the first plugin
         moduleButton = Button()
@@ -147,7 +147,7 @@ class TestTreeManager(unittest.TestCase):
         result1 = force1_mod.run_as(efield_pt, p0, pcs)
         result2 = force3_mod.run_as(efield_pt, p0, pcs)
         #get player shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #add one of each nodes to the tree
         moduleButton = Button()

--- a/tests/test_utility_manager.py
+++ b/tests/test_utility_manager.py
@@ -1,0 +1,44 @@
+#stop automatic kivy methods
+from kivy.config import Config
+# Set Kivy to dummy backend to prevent window creation
+Config.set('graphics', 'backend', 'dummy')
+
+# test_pluginplayer.py
+import unittest
+from pluginplayer_shell import PluginPlayerShell
+
+#kivy button for instance
+from kivy.uix.button import Button
+
+#pluginplay_example types
+from pluginplay_examples import PointCharge
+
+
+import sys
+
+class TestutilityManager(unittest.TestCase):
+
+    def test_class_types(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+
+
+
+    def test_new_type(self):
+        #get a new shell
+        player = PluginPlayerShell.get_shell(self)
+        
+        #set the id for the back button
+        backButton = Button()
+        backButton.id = '0 0'
+
+        player.utility_manager.custom_declaration_widget.text = 'pluginplay_examples PointCharge'
+        
+        #call the new_type function to add it to the list of types
+        player.utility_manager.new_type(backButton, player)
+
+        assert hasattr(sys.modules['__main__'], PointCharge.__name__), f"{PointCharge.__name__} doesn't exist in the main module after attempted import."
+        self.assertEquals(player.utility_manager.imported_classes[0], "PointCharge", "Did not add to listed imported class types")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utility_manager.py
+++ b/tests/test_utility_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #stop automatic kivy methods
 from kivy.config import Config
 # Set Kivy to dummy backend to prevent window creation
@@ -13,8 +27,8 @@ from kivy.uix.button import Button
 #pluginplay_example types
 from pluginplay_examples import PointCharge
 
-
 import sys
+
 
 class TestutilityManager(unittest.TestCase):
 
@@ -22,23 +36,26 @@ class TestutilityManager(unittest.TestCase):
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
 
-
-
     def test_new_type(self):
         #get a new shell
         player = PluginPlayerShell.get_shell(self)
-        
+
         #set the id for the back button
         backButton = Button()
         backButton.id = '0 0'
 
         player.utility_manager.custom_declaration_widget.text = 'pluginplay_examples PointCharge'
-        
+
         #call the new_type function to add it to the list of types
         player.utility_manager.new_type(backButton, player)
 
-        assert hasattr(sys.modules['__main__'], PointCharge.__name__), f"{PointCharge.__name__} doesn't exist in the main module after attempted import."
-        self.assertEquals(player.utility_manager.imported_classes[0], "PointCharge", "Did not add to listed imported class types")
+        assert hasattr(
+            sys.modules['__main__'], PointCharge.__name__
+        ), f"{PointCharge.__name__} doesn't exist in the main module after attempted import."
+        self.assertEquals(player.utility_manager.imported_classes[0],
+                          "PointCharge",
+                          "Did not add to listed imported class types")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utilitymanager.py
+++ b/tests/test_utilitymanager.py
@@ -34,11 +34,11 @@ class TestutilityManager(unittest.TestCase):
 
     def test_class_types(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
     def test_new_type(self):
         #get a new shell
-        player = PluginPlayerShell.get_shell(self)
+        player = PluginPlayerShell()
 
         #set the id for the back button
         backButton = Button()


### PR DESCRIPTION
Tree Manager

- [ ] implement a new view_submodule_tree to view a module's submodule tree by iterating through the module manager.

PluginPlayer

- [ ] Add scrolling/zooming capabilities on the tree_section
- [ ] add standardized pixel length throughout the application using kivy.metrics dp()

NodeManager

- [ ] edit link_submod to handle setting the submodule of a submodule

NodeWidget

- [ ] Implement a way to differentiate between normal module node's and submodule node's

NodeWidgetManager

- [ ] edit view_config to not show inputs on a submodule node

PluginManager

- [ ]  Add a duplicate button to copy a module and place in plugin.modules, add to mm, refresh with plugin_view()
